### PR TITLE
Fixed kmer list bug

### DIFF
--- a/core/kover/learning/set_covering_machine/rules.py
+++ b/core/kover/learning/set_covering_machine/rules.py
@@ -73,7 +73,7 @@ class LazyKmerRuleList(object):
         else:
             type = "presence"
             kmer_idx = self.kmer_by_rule[idx]
-        return KmerRule(kmer_idx, self.kmer_sequences[kmer_idx], type)
+        return KmerRule(idx % len(self.kmer_sequences), self.kmer_sequences[kmer_idx], type)
 
     def __len__(self):
         return self.n_rules

--- a/core/setup.py
+++ b/core/setup.py
@@ -11,7 +11,7 @@ class build_ext(_build_ext):
 
 setup(
     name = "kover",
-    version = "0.1.0",
+    version = "1.0.1",
     packages = find_packages(),
 
     cmdclass={'build_ext':build_ext},


### PR DESCRIPTION
Nature of the bug
==
* Rules generated by LazyKmerRuleList class pointed to incorrect indices in the kmer_marix if the kmer_by_matrix_column was not a contiguous range of integers.

Consequences
==
* No impact when using kmer data in the TSV (surveyor) format
* When using other types of data, if the kmer_by_matrix_column is not a sequence, the model constructed by the algorithm refers to the wrong columns in kmer_matrix resulting in erroneous models