### PR TITLE
Kmer blacklisting

### DIFF
--- a/core/kover/dataset/create.py
+++ b/core/kover/dataset/create.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#!/usr/bin/env python
 """
 	Kover: Learn interpretable computational phenotyping models from k-merized genomic data
 	Copyright (C) 2015  Alexandre Drouin

--- a/core/kover/dataset/create.py
+++ b/core/kover/dataset/create.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+#!/usr/bin/env python
 """
 	Kover: Learn interpretable computational phenotyping models from k-merized genomic data
 	Copyright (C) 2015  Alexandre Drouin

--- a/core/kover/learning/experiment.py
+++ b/core/kover/learning/experiment.py
@@ -417,6 +417,10 @@ def _bound_selection(dataset_file, split_name, model_types, p_values, max_rules,
 
 
 def _find_rule_blacklist(dataset_file, kmer_blacklist_file, warning_callback):
+    """
+    Finds the index of the rules that must be blacklisted.
+    
+    """
     dataset = KoverDataset(dataset_file)
     
     # Find all rules to blacklist
@@ -425,13 +429,15 @@ def _find_rule_blacklist(dataset_file, kmer_blacklist_file, warning_callback):
         kmers_to_blacklist = _parse_kmer_blacklist(kmer_blacklist_file, dataset.kmer_length)
 	
         if kmers_to_blacklist:
-            kmer_sequences = np.array(dataset.kmer_sequences).tolist()
+	    # XXX: the k-mers are upper-cased to avoid not finding a match because of the character case
+            kmer_sequences = np.array([x.upper() for x in dataset.kmer_sequences]).tolist()
             kmer_by_matrix_column = np.array(dataset.kmer_by_matrix_column).tolist() # XXX: each k-mer is there only once (see wiki)
             n_kmers = len(kmer_sequences)    
 	
             kmers_not_found = []
 	    rule_blacklist = []
             for k in kmers_to_blacklist:
+                k = k.upper()
                 try:
                     presence_rule_idx = kmer_by_matrix_column.index(kmer_sequences.index(k))
 		    absence_rule_idx = presence_rule_idx + n_kmers

--- a/core/kover/learning/experiment.py
+++ b/core/kover/learning/experiment.py
@@ -487,19 +487,19 @@ def learn(dataset_file, split_name, model_type, p, kmer_blacklist_file, max_rule
         best_model, \
         best_rule_importances, \
         best_predictor_equiv_rules = _bound_selection(dataset_file=dataset_file, split_name=split_name, model_type=model_type, 
-                                                        p_values=p, max_rules=max_rules, max_equiv_rules=max_equiv_rules, 
-                                                        rule_blacklist=rule_blacklist, bound_delta=bound_delta, 
-                                                        bound_max_genome_size=bound_max_genome_size, n_cpu=n_cpu, 
-                                                        random_generator=random_generator, progress_callback=progress_callback, 
-                                                        warning_callback=warning_callback, error_callback=error_callback)
+                                                      p_values=p, max_rules=max_rules, max_equiv_rules=max_equiv_rules, 
+                                                      rule_blacklist=rule_blacklist, bound_delta=bound_delta, 
+                                                      bound_max_genome_size=bound_max_genome_size, n_cpu=n_cpu, 
+                                                      random_generator=random_generator, progress_callback=progress_callback, 
+                                                      warning_callback=warning_callback, error_callback=error_callback)
     elif parameter_selection == "cv":
         n_folds = len(dataset.get_split(split_name).folds)
         if n_folds < 1:
             error_callback(Exception("Cross-validation cannot be performed on a split with no folds."))
         best_hp_score, best_hp = _cross_validation(dataset_file=dataset_file, split_name=split_name, model_types=model_type,
-                                                    p_values=p, max_rules=max_rules, rule_blacklist=rule_blacklist, n_cpu=n_cpu, 
-                                                    progress_callback=progress_callback, warning_callback=warning_callback, 
-                                                    error_callback=error_callback)
+                                                   p_values=p, max_rules=max_rules, rule_blacklist=rule_blacklist, n_cpu=n_cpu, 
+                                                   progress_callback=progress_callback, warning_callback=warning_callback, 
+                                                   error_callback=error_callback)
     else:
         # Use the first value provided for each parameter
         best_hp = {"model_type": model_type[0], "p": p[0], "max_rules": max_rules}
@@ -514,8 +514,8 @@ def learn(dataset_file, split_name, model_type, p, kmer_blacklist_file, max_rule
     else:
         model, rule_importances, \
         equivalent_rules = _full_train(dataset=dataset, split_name=split_name, model_type=best_hp["model_type"], p=best_hp["p"], 
-                                        max_rules=best_hp["max_rules"], max_equiv_rules=max_equiv_rules, rule_blacklist=rule_blacklist, 
-                                        random_generator=random_generator, progress_callback=progress_callback)
+                                       max_rules=best_hp["max_rules"], max_equiv_rules=max_equiv_rules, rule_blacklist=rule_blacklist, 
+                                       random_generator=random_generator, progress_callback=progress_callback)
 
     split = dataset.get_split(split_name)
     train_example_idx = split.train_genome_idx

--- a/core/kover/learning/experiment.py
+++ b/core/kover/learning/experiment.py
@@ -32,7 +32,7 @@ from ..dataset.ds import KoverDataset
 from .set_covering_machine.models import ConjunctionModel, DisjunctionModel
 from .set_covering_machine.rules import LazyKmerRuleList, KmerRuleClassifications
 from .set_covering_machine.scm import SetCoveringMachine
-from ..utils import _duplicate_last_element, _unpack_binary_bytes_from_ints
+from ..utils import _duplicate_last_element, _unpack_binary_bytes_from_ints, _parse_blacklist
 
 def _get_metrics(predictions, answers):
     if len(predictions.shape) == 1:
@@ -109,7 +109,7 @@ def _predictions(model, kmer_matrix, train_example_idx, test_example_idx, progre
     return train_predictions, test_predictions
 
 
-def _cv_score_hp(hp_values, max_rules, dataset_file, split_name):
+def _cv_score_hp(hp_values, max_rules, dataset_file, split_name, rule_blacklist):
     model_type = hp_values[0]
     p = hp_values[1]
 
@@ -155,6 +155,7 @@ def _cv_score_hp(hp_values, max_rules, dataset_file, split_name):
                       rule_classifications=rule_classifications,
                       positive_example_idx=positive_example_idx,
                       negative_example_idx=negative_example_idx,
+                      rule_blacklist=rule_blacklist,
                       tiebreaker=tiebreaker,
                       iteration_callback=iteration_callback)
         test_predictions_by_model_length = np.array(_duplicate_last_element(test_predictions_by_model_length, max_rules))
@@ -169,7 +170,7 @@ def _cv_score_hp(hp_values, max_rules, dataset_file, split_name):
     return (model_type, p, best_model_length), best_hp_score
 
 
-def _cross_validation(dataset_file, split_name, model_types, p_values, max_rules, n_cpu, progress_callback,
+def _cross_validation(dataset_file, split_name, model_types, p_values, max_rules, rule_blacklist, n_cpu, progress_callback,
                       warning_callback, error_callback):
     """
     Returns the best parameter combination and its cv score
@@ -179,7 +180,7 @@ def _cross_validation(dataset_file, split_name, model_types, p_values, max_rules
 
     logging.debug("Using %d CPUs." % n_cpu)
     pool = Pool(processes=n_cpu)
-    hp_eval_func = partial(_cv_score_hp, dataset_file=dataset_file, split_name=split_name, max_rules=max_rules)
+    hp_eval_func = partial(_cv_score_hp, dataset_file=dataset_file, split_name=split_name, max_rules=max_rules, rule_blacklist=rule_blacklist)
 
     best_hp_score = 1.0
     best_hp = {"model_type": None, "p": None, "max_rules": None}
@@ -199,7 +200,7 @@ def _cross_validation(dataset_file, split_name, model_types, p_values, max_rules
     return best_hp_score, best_hp
 
 
-def _full_train(dataset, split_name, model_type, p, max_rules, max_equiv_rules, random_generator, progress_callback):
+def _full_train(dataset, split_name, model_type, p, max_rules, max_equiv_rules, rule_blacklist, random_generator, progress_callback):
     full_train_progress = {"n_rules": 0.0}
 
     def _iteration_callback(iteration_infos, model_type, equivalent_rules):
@@ -248,6 +249,7 @@ def _full_train(dataset, split_name, model_type, p, max_rules, max_equiv_rules, 
                   rule_classifications=rule_classifications,
                   positive_example_idx=positive_example_idx,
                   negative_example_idx=negative_example_idx,
+                  rule_blacklist= rule_blacklist,
                   tiebreaker=partial(_tiebreaker,
                                      rule_risks=np.hstack((split.unique_risk_by_kmer[...],
                                                            split.unique_risk_by_anti_kmer[...])),
@@ -288,7 +290,7 @@ def _bound(train_predictions, train_answers, train_example_idx, model, delta, ma
                                                  (216 * delta))))
 
 
-def _bound_score_hp(hp_values, max_rules, dataset_file, split_name, max_equiv_rules, bound_delta,
+def _bound_score_hp(hp_values, max_rules, dataset_file, split_name, max_equiv_rules, rule_blacklist, bound_delta,
                     bound_max_genome_size, random_generator):
     model_type = hp_values[0]
     p = hp_values[1]
@@ -366,6 +368,7 @@ def _bound_score_hp(hp_values, max_rules, dataset_file, split_name, max_equiv_ru
                   rule_classifications=rule_classifications,
                   positive_example_idx=positive_example_idx,
                   negative_example_idx=negative_example_idx,
+                  rule_blacklist= rule_blacklist,
                   tiebreaker=tiebreaker,
                   iteration_callback=iteration_callback,
                   iteration_rule_importances=True)
@@ -380,7 +383,7 @@ def _bound_score_hp(hp_values, max_rules, dataset_file, split_name, max_equiv_ru
     return (model_type, p, best_model_length), best_hp_score, best_model, best_rule_importances, best_equivalent_rules
 
 
-def _bound_selection(dataset_file, split_name, model_types, p_values, max_rules, max_equiv_rules, bound_delta,
+def _bound_selection(dataset_file, split_name, model_types, p_values, max_rules, max_equiv_rules, rule_blacklist, bound_delta,
                      bound_max_genome_size, n_cpu, random_generator, progress_callback, warning_callback,
                      error_callback):
     n_hp_combinations = len(model_types) * len(p_values)
@@ -389,7 +392,7 @@ def _bound_selection(dataset_file, split_name, model_types, p_values, max_rules,
     logging.debug("Using %d CPUs." % n_cpu)
     pool = Pool(processes=n_cpu)
     hp_eval_func = partial(_bound_score_hp, dataset_file=dataset_file, split_name=split_name, max_rules=max_rules,
-                           max_equiv_rules=max_equiv_rules, bound_delta=bound_delta,
+                           max_equiv_rules=max_equiv_rules, rule_blacklist=rule_blacklist, bound_delta=bound_delta,
                            bound_max_genome_size=bound_max_genome_size, random_generator=random_generator)
 
     best_hp_score = 1.0
@@ -413,7 +416,7 @@ def _bound_selection(dataset_file, split_name, model_types, p_values, max_rules,
     return best_hp_score, best_hp, best_model, best_rule_importances, best_equiv_rules
 
 
-def learn(dataset_file, split_name, model_type, p, max_rules, max_equiv_rules, parameter_selection, n_cpu, random_seed,
+def learn(dataset_file, split_name, model_type, p, kmer_blacklist_file, max_rules, max_equiv_rules, parameter_selection, n_cpu, random_seed,
           bound_delta=None, bound_max_genome_size=None, progress_callback=None, warning_callback=None, error_callback=None):
     """
     parameter_selection: bound, cv, none (use first value of each if multiple)
@@ -438,6 +441,15 @@ def learn(dataset_file, split_name, model_type, p, max_rules, max_equiv_rules, p
 
     dataset = KoverDataset(dataset_file)
 
+    rule_blacklist = []
+    if kmer_blacklist_file is not None:
+        kmers_to_blacklist = _parse_blacklist(kmer_blacklist_file)
+        if not('' in kmers_to_blacklist):
+            kmer_sequences = (np.array(dataset.kmer_sequences)).tolist()
+            kmer_by_rule = (np.array(dataset.kmer_by_matrix_column)).tolist()
+            idx_to_blacklist = [kmer_by_rule.index(kmer_sequences.index(k)) for k in kmers_to_blacklist]
+            rule_blacklist = reduce(list.__add__, [[i, i + len(kmer_by_rule)] for i in idx_to_blacklist])
+            
     # Score the hyperparameter combinations
     # ------------------------------------------------------------------------------------------------------------------
     if parameter_selection == "bound":
@@ -451,14 +463,14 @@ def learn(dataset_file, split_name, model_type, p, max_rules, max_equiv_rules, p
         best_model, \
         best_rule_importances, \
         best_predictor_equiv_rules = _bound_selection(dataset_file, split_name, model_type, p, max_rules,
-                                                      max_equiv_rules, bound_delta, bound_max_genome_size, n_cpu,
-                                                      random_generator, progress_callback, warning_callback,
+                                                      max_equiv_rules, rule_blacklist, bound_delta, bound_max_genome_size, 
+                                                      n_cpu, random_generator, progress_callback, warning_callback,
                                                       error_callback)
     elif parameter_selection == "cv":
         n_folds = len(dataset.get_split(split_name).folds)
         if n_folds < 1:
             error_callback(Exception("Cross-validation cannot be performed on a split with no folds."))
-        best_hp_score, best_hp = _cross_validation(dataset_file, split_name, model_type, p, max_rules, n_cpu,
+        best_hp_score, best_hp = _cross_validation(dataset_file, split_name, model_type, p, max_rules, rule_blacklist, n_cpu,
                                                    progress_callback, warning_callback, error_callback)
     else:
         # Use the first value provided for each parameter
@@ -474,8 +486,8 @@ def learn(dataset_file, split_name, model_type, p, max_rules, max_equiv_rules, p
     else:
         model, rule_importances, \
         equivalent_rules = _full_train(dataset, split_name, best_hp["model_type"], best_hp["p"],
-                                                        best_hp["max_rules"], max_equiv_rules, random_generator,
-                                                        progress_callback)
+                                                        best_hp["max_rules"], max_equiv_rules, rule_blacklist,
+                                                        random_generator, progress_callback)
 
     split = dataset.get_split(split_name)
     train_example_idx = split.train_genome_idx

--- a/core/kover/learning/experiment.py
+++ b/core/kover/learning/experiment.py
@@ -440,11 +440,11 @@ def learn(dataset_file, split_name, model_type, p, kmer_blacklist_file, max_rule
     p = np.unique(p)
 
     dataset = KoverDataset(dataset_file)
-
+    
+    # Find all rules to blacklist
     rule_blacklist = []
     if kmer_blacklist_file is not None:
         kmers_to_blacklist = _parse_blacklist(kmer_blacklist_file)
-        print(kmers_to_blacklist)
         if kmers_to_blacklist:
             kmer_sequences = (np.array(dataset.kmer_sequences)).tolist()
             kmer_by_rule = (np.array(dataset.kmer_by_matrix_column)).tolist()

--- a/core/kover/learning/experiment.py
+++ b/core/kover/learning/experiment.py
@@ -32,7 +32,7 @@ from ..dataset.ds import KoverDataset
 from .set_covering_machine.models import ConjunctionModel, DisjunctionModel
 from .set_covering_machine.rules import LazyKmerRuleList, KmerRuleClassifications
 from .set_covering_machine.scm import SetCoveringMachine
-from ..utils import _duplicate_last_element, _unpack_binary_bytes_from_ints, _parse_blacklist
+from ..utils import _duplicate_last_element, _unpack_binary_bytes_from_ints, _parse_kmer_blacklist
 
 def _get_metrics(predictions, answers):
     if len(predictions.shape) == 1:
@@ -422,7 +422,7 @@ def _find_rule_blacklist(dataset_file, kmer_blacklist_file, warning_callback):
     # Find all rules to blacklist
     rule_blacklist = []
     if kmer_blacklist_file is not None:
-        kmers_to_blacklist = _parse_blacklist(kmer_blacklist_file, dataset.kmer_length)
+        kmers_to_blacklist = _parse_kmer_blacklist(kmer_blacklist_file, dataset.kmer_length)
 	
         if kmers_to_blacklist:
             kmer_sequences = np.array(dataset.kmer_sequences).tolist()

--- a/core/kover/learning/experiment.py
+++ b/core/kover/learning/experiment.py
@@ -469,8 +469,8 @@ def learn(dataset_file, split_name, model_type, p, kmer_blacklist_file, max_rule
     p = np.unique(p)
 
     rule_blacklist = _find_rule_blacklist(dataset_file=dataset_file, 
-                                            kmer_blacklist_file=kmer_blacklist_file,
-                                            warning_callback=warning_callback)
+                                          kmer_blacklist_file=kmer_blacklist_file,
+                                          warning_callback=warning_callback)
     
     dataset = KoverDataset(dataset_file)
             

--- a/core/kover/learning/experiment.py
+++ b/core/kover/learning/experiment.py
@@ -448,8 +448,18 @@ def learn(dataset_file, split_name, model_type, p, kmer_blacklist_file, max_rule
         if kmers_to_blacklist:
             kmer_sequences = (np.array(dataset.kmer_sequences)).tolist()
             kmer_by_rule = (np.array(dataset.kmer_by_matrix_column)).tolist()
-            idx_to_blacklist = [kmer_by_rule.index(kmer_sequences.index(k)) for k in kmers_to_blacklist]
+            
+            idx_to_blacklist = []
+            kmers_not_found = []
+            for k in kmers_to_blacklist:
+                try:
+                    idx_to_blacklist.append(kmer_by_rule.index(kmer_sequences.index(k)))
+                except ValueError:
+                    kmers_not_found.append(k)
             rule_blacklist = reduce(list.__add__, [[i, i + len(kmer_by_rule)] for i in idx_to_blacklist])
+            
+            if(len(kmers_not_found) > 0):
+                warning_callback("The following kmers could not be found in the dataset: " + ", ".join(kmers_not_found))
             
     # Score the hyperparameter combinations
     # ------------------------------------------------------------------------------------------------------------------

--- a/core/kover/learning/experiment.py
+++ b/core/kover/learning/experiment.py
@@ -444,7 +444,8 @@ def learn(dataset_file, split_name, model_type, p, kmer_blacklist_file, max_rule
     rule_blacklist = []
     if kmer_blacklist_file is not None:
         kmers_to_blacklist = _parse_blacklist(kmer_blacklist_file)
-        if not('' in kmers_to_blacklist):
+        print(kmers_to_blacklist)
+        if kmers_to_blacklist:
             kmer_sequences = (np.array(dataset.kmer_sequences)).tolist()
             kmer_by_rule = (np.array(dataset.kmer_by_matrix_column)).tolist()
             idx_to_blacklist = [kmer_by_rule.index(kmer_sequences.index(k)) for k in kmers_to_blacklist]

--- a/core/kover/learning/set_covering_machine/rules.py
+++ b/core/kover/learning/set_covering_machine/rules.py
@@ -74,7 +74,7 @@ class LazyKmerRuleList(object):
             type = "presence"
             kmer_idx = self.kmer_by_rule[idx]
         return KmerRule(idx % len(self.kmer_sequences), self.kmer_sequences[kmer_idx], type)
-
+    
     def __len__(self):
         return self.n_rules
 

--- a/core/kover/learning/set_covering_machine/scm.py
+++ b/core/kover/learning/set_covering_machine/scm.py
@@ -81,7 +81,7 @@ class BaseSetCoveringMachine(object):
             rule_blacklist = np.unique(rule_blacklist)
             if len(rule_blacklist) == rule_classifications.shape[1]:
                 raise ValueError("The blacklist cannot include all the rules.")
-            logging.debug("Blacklisting : " + str(len(rule_blacklist)/2) + " kmers (" + str(len(rule_blacklist)) + " rules)")
+            logging.debug("Blacklisting: {0:d} kmers ({1:d} rules)".format(len(rule_blacklist) / 2, len(rule_blacklist)))
 
         training_example_idx = np.hstack((positive_example_idx, negative_example_idx))  # Needed for rule importances
         model_rules_idx = []  # Contains the index of the rules in the model

--- a/core/kover/learning/set_covering_machine/scm.py
+++ b/core/kover/learning/set_covering_machine/scm.py
@@ -81,7 +81,7 @@ class BaseSetCoveringMachine(object):
             rule_blacklist = np.unique(rule_blacklist)
             if len(rule_blacklist) == rule_classifications.shape[1]:
                 raise ValueError("The blacklist cannot include all the rules.")
-            logging.debug("The following rules are blacklisted and will not be considered:" + str(rule_blacklist))
+            logging.debug("Blacklisting : " + str(len(rule_blacklist)/2) + " kmers (" + str(len(rule_blacklist)) + " rules)")
 
         training_example_idx = np.hstack((positive_example_idx, negative_example_idx))  # Needed for rule importances
         model_rules_idx = []  # Contains the index of the rules in the model

--- a/core/kover/utils.py
+++ b/core/kover/utils.py
@@ -181,6 +181,12 @@ def _parse_kmer_blacklist(blacklist_path, expected_kmer_len):
         # Filtering for empty strings (empty lines)
         data = [x for x in data if x]
     
+    def is_valid_kmer(k):
+        return len(set(k).difference(["A", "C", "G", "T"])) == 0
+    for kmer in data:
+        if not is_valid_kmer(kmer):
+            raise ValueError("{} is not a valid DNA sequence".format(kmer))
+
     if not(all(len(kmer) == expected_kmer_len for kmer in data)):
         raise ValueError("Extracted k-mers to blacklist do not have all the same length as the dataset k-mers")
 	

--- a/core/kover/utils.py
+++ b/core/kover/utils.py
@@ -169,7 +169,8 @@ def _parse_kmer_blacklist(blacklist_path, expected_kmer_len):
     data = []
     
     # Fasta file format
-    if blacklist_path.endswith(".fasta"):
+    fasta_extensions = [".fasta", ".fa", ".fas", ".fna"]
+    if any(blacklist_path.endswith(extension) for extension in fasta_extensions):
         data = _fasta_to_sequences(blacklist_path)
             
     # Other file format (text file with one kmer per line)

--- a/core/kover/utils.py
+++ b/core/kover/utils.py
@@ -165,7 +165,7 @@ def _unpack_binary_bytes_from_ints(a):
     return b
 
     
-def _parse_blacklist(blacklist_path, expected_kmer_len):
+def _parse_kmer_blacklist(blacklist_path, expected_kmer_len):
     data = []
     
     # Fasta file format

--- a/core/kover/utils.py
+++ b/core/kover/utils.py
@@ -129,19 +129,34 @@ def _unpack_binary_bytes_from_ints(a):
 
     return b
     
-def _parse_blacklist(blacklist_path):
-    # Fasta file formar
+def _parse_blacklist(blacklist_path, expected_kmer_len):
+    data = []
+    
+    # Fasta file format
     if blacklist_path.endswith(".fasta"):
         with open(blacklist_path, "r") as fasta_file:
+            #Loading data
             data = fasta_file.read()
+            
+            # Splitting on description line
             data = data.split('>')
+            
+            # Filtering for empty strings
             data = [x for x in data if x]
-            data= [(x.split('\n', 1))[1].rstrip('\n') for x in data]
-            return data
+            
+            # Splitting after desccription line and removing empty lines under the k-mer
+            data = [(x.split('\n', 1))[1].rstrip('\n') for x in data]
+            
     # Other file format (one kmer per line)
     else:
+        # Loading data and splitting on every line
         data = [l.rstrip('\n') for l in open(blacklist_path, "r")]
+        
+        # Filtering for empty strings (empty lines)
         data = [x for x in data if x]
-        return data
+    
+    if not(all(len(kmer) == expected_kmer_len for kmer in data)):
+        raise ValueError("Extracted k-mers to blacklist do not have all the same length as the dataset k-mers")
+    return data
     
     

--- a/core/kover/utils.py
+++ b/core/kover/utils.py
@@ -130,6 +130,7 @@ def _unpack_binary_bytes_from_ints(a):
     return b
     
 def _parse_blacklist(blacklist_path):
+    # Fasta file formar
     if blacklist_path.endswith(".fasta"):
         with open(blacklist_path, "r") as fasta_file:
             data = fasta_file.read()
@@ -137,6 +138,7 @@ def _parse_blacklist(blacklist_path):
             data = [x for x in data if x]
             data= [(x.split('\n', 1))[1].rstrip('\n') for x in data]
             return data
+    # Other file format (one kmer per line)
     else:
         data = [l.rstrip('\n') for l in open(blacklist_path, "r")]
         data = [x for x in data if x]

--- a/core/kover/utils.py
+++ b/core/kover/utils.py
@@ -182,7 +182,7 @@ def _parse_kmer_blacklist(blacklist_path, expected_kmer_len):
         data = [x for x in data if x]
     
     def is_valid_kmer(k):
-        return len(set(k).difference(["A", "C", "G", "T"])) == 0
+        return len(set(k).difference(["A", "C", "G", "T", "a", "c", "g", "t"])) == 0
     for kmer in data:
         if not is_valid_kmer(kmer):
             raise ValueError("{} is not a valid DNA sequence".format(kmer))

--- a/core/kover/utils.py
+++ b/core/kover/utils.py
@@ -128,3 +128,8 @@ def _unpack_binary_bytes_from_ints(a):
         packed_rows += 1
 
     return b
+    
+def _parse_blacklist(blacklist_path):
+    return [l.rstrip('\n') for l in open(blacklist_path, "r")]
+    
+    

--- a/core/kover/utils.py
+++ b/core/kover/utils.py
@@ -65,7 +65,7 @@ def _fasta_to_sequences(path):
     for l in open(path, "r"):
         if l.startswith(">"):
             if buffer is not None:
-                contigs.append(buffer.lower())
+                contigs.append(buffer.upper())
                 buffer = ""
         else:
             if buffer is None:
@@ -73,7 +73,7 @@ def _fasta_to_sequences(path):
             else:
                 buffer += l.strip()
     if buffer is not None and buffer != "":
-        contigs.append(buffer.lower())
+        contigs.append(buffer.upper())
     return contigs
 
 

--- a/core/kover/utils.py
+++ b/core/kover/utils.py
@@ -130,6 +130,16 @@ def _unpack_binary_bytes_from_ints(a):
     return b
     
 def _parse_blacklist(blacklist_path):
-    return [l.rstrip('\n') for l in open(blacklist_path, "r")]
+    if blacklist_path.endswith(".fasta"):
+        with open(blacklist_path, "r") as fasta_file:
+            data = fasta_file.read()
+            data = data.split('>')
+            data = [x for x in data if x]
+            data= [(x.split('\n', 1))[1].rstrip('\n') for x in data]
+            return data
+    else:
+        data = [l.rstrip('\n') for l in open(blacklist_path, "r")]
+        data = [x for x in data if x]
+        return data
     
     

--- a/core/setup.py
+++ b/core/setup.py
@@ -11,7 +11,7 @@ class build_ext(_build_ext):
 
 setup(
     name = "kover",
-    version = "1.2.2",
+    version = "1.3.0",
     packages = find_packages(),
 
     cmdclass={'build_ext':build_ext},

--- a/interfaces/command_line.py
+++ b/interfaces/command_line.py
@@ -538,6 +538,8 @@ The most commonly used commands are:
                                  'You can specify multiple space separated values. Refer to the documentation for '
                                  'more information.',
                             default=[0.1, 0.316, 0.562, 1.0, 1.778, 3.162, 10.0, 999999.0])
+        parser.add_argument('--kmer-blacklist', help='A file containing a list of kmers to blacklist from being used to create rules.'
+                                                        'File format : one kmer per line ', required=False)
         parser.add_argument('--max-rules', type=int, help='The maximum number of rules that can be included in the '
                                                           'model.', default=10)
         parser.add_argument('--max-equiv-rules', type=int, help='The maximum number of equivalent rules to report for '
@@ -564,7 +566,7 @@ The most commonly used commands are:
                                  'it does not exist.', default='.')
         parser.add_argument('-x', '--progress', help='Shows a progress bar for the execution.', action='store_true')
         parser.add_argument('-v', '--verbose', help='Sets the verbosity level.', default=False, action='store_true')
-
+    
         # If no argument has been specified, default to help
         if len(argv) == 2:
             argv.append("--help")
@@ -596,7 +598,7 @@ The most commonly used commands are:
                   "Use 'kover dataset split' to create folds."
             exit()
         del dataset
-
+    
         if args.verbose:
             logging.basicConfig(level=logging.DEBUG,
                                 format="%(asctime)s.%(msecs)d %(levelname)s %(module)s - %(funcName)s [%(process)d]: %(message)s")
@@ -626,6 +628,7 @@ The most commonly used commands are:
                                 split_name=args.split,
                                 model_type=args.model_type,
                                 p=args.p,
+                                kmer_blacklist_file=args.kmer_blacklist,
                                 max_rules=args.max_rules,
                                 max_equiv_rules=args.max_equiv_rules,
                                 bound_delta=0.05,  # We use a fixed 5% delta to simplify the user experience

--- a/interfaces/command_line.py
+++ b/interfaces/command_line.py
@@ -22,9 +22,10 @@
 import argparse
 import logging
 
-from tempfile import gettempdir
+from os.path import abspath
 from pkg_resources import get_distribution
 from sys import argv
+from tempfile import gettempdir
 
 KOVER_DESCRIPTION = "Kover: Learn interpretable computational phenotyping models from k-merized genomic data"
 VERSION = "1.2.0"
@@ -629,7 +630,7 @@ The most commonly used commands are:
                                 split_name=args.split,
                                 model_type=args.model_type,
                                 p=args.p,
-                                kmer_blacklist_file=args.kmer_blacklist,
+                                kmer_blacklist_file=None if args.kmer_blacklist is None else abspath(args.kmer_blacklist),
                                 max_rules=args.max_rules,
                                 max_equiv_rules=args.max_equiv_rules,
                                 bound_delta=0.05,  # We use a fixed 5% delta to simplify the user experience

--- a/interfaces/command_line.py
+++ b/interfaces/command_line.py
@@ -539,7 +539,7 @@ The most commonly used commands are:
                                  'more information.',
                             default=[0.1, 0.316, 0.562, 1.0, 1.778, 3.162, 10.0, 999999.0])
         parser.add_argument('--kmer-blacklist', help='A file containing a list of kmers to blacklist from being used to create rules.'
-                                                        'File format : either a fasta file or a text file with one kmer per line', required=False)
+                                                        'File format: either a fasta file or a text file with one kmer per line', required=False)
         parser.add_argument('--max-rules', type=int, help='The maximum number of rules that can be included in the '
                                                           'model.', default=10)
         parser.add_argument('--max-equiv-rules', type=int, help='The maximum number of equivalent rules to report for '

--- a/interfaces/command_line.py
+++ b/interfaces/command_line.py
@@ -538,8 +538,9 @@ The most commonly used commands are:
                                  'You can specify multiple space separated values. Refer to the documentation for '
                                  'more information.',
                             default=[0.1, 0.316, 0.562, 1.0, 1.778, 3.162, 10.0, 999999.0])
-        parser.add_argument('--kmer-blacklist', help='A file containing a list of kmers to blacklist from being used to create rules.'
-                                                        'File format: either a fasta file or a text file with one kmer per line', required=False)
+        parser.add_argument('--kmer-blacklist', help='A file containing a list of k-mers to remove from the analysis.'
+                                                        'These k-mers guaranteed not to be used in the models.'
+                                                        'File format: fasta file or text file with one k-mer per line.', required=False)
         parser.add_argument('--max-rules', type=int, help='The maximum number of rules that can be included in the '
                                                           'model.', default=10)
         parser.add_argument('--max-equiv-rules', type=int, help='The maximum number of equivalent rules to report for '

--- a/interfaces/command_line.py
+++ b/interfaces/command_line.py
@@ -28,7 +28,7 @@ from sys import argv
 from tempfile import gettempdir
 
 KOVER_DESCRIPTION = "Kover: Learn interpretable computational phenotyping models from k-merized genomic data"
-VERSION = "1.2.0"
+VERSION = "1.3.0"
 
 class KoverDatasetCreationTool(object):
 

--- a/interfaces/command_line.py
+++ b/interfaces/command_line.py
@@ -539,7 +539,7 @@ The most commonly used commands are:
                                  'more information.',
                             default=[0.1, 0.316, 0.562, 1.0, 1.778, 3.162, 10.0, 999999.0])
         parser.add_argument('--kmer-blacklist', help='A file containing a list of kmers to blacklist from being used to create rules.'
-                                                        'File format : one kmer per line ', required=False)
+                                                        'File format : either a fasta file or a text file with one kmer per line', required=False)
         parser.add_argument('--max-rules', type=int, help='The maximum number of rules that can be included in the '
                                                           'model.', default=10)
         parser.add_argument('--max-equiv-rules', type=int, help='The maximum number of equivalent rules to report for '


### PR DESCRIPTION
### Summary
This new feature allows to blacklist kmers from being used to create rules when learning on a dataset.  
### Utilisation
When using the `kover learn` command, simply add the argument `--kmer-blacklist` followed by the path to a file containing all kmers to blacklist.
### File format
1. Fasta file
2. Text file with one kmer per line